### PR TITLE
Serial glt

### DIFF
--- a/apply_glt_serial.py
+++ b/apply_glt_serial.py
@@ -1,9 +1,15 @@
+"""
+Apply a (possibly multi-file) per-pixel spatial reference, in serial (rayless).
+
+Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
+"""
+
+
 import argparse
 import numpy as np
 import pandas as pd
 from osgeo import gdal
 from spectral.io import envi
-from typing import List
 import emit_utils.file_checks
 
 from emit_utils.file_checks import envi_header

--- a/apply_glt_serial.py
+++ b/apply_glt_serial.py
@@ -3,11 +3,7 @@ import numpy as np
 import pandas as pd
 from osgeo import gdal
 from spectral.io import envi
-import logging
 from typing import List
-import time
-import os
-import multiprocessing
 import emit_utils.file_checks
 
 from emit_utils.file_checks import envi_header

--- a/apply_glt_serial.py
+++ b/apply_glt_serial.py
@@ -1,0 +1,118 @@
+import argparse
+import numpy as np
+import pandas as pd
+from osgeo import gdal
+from spectral.io import envi
+import logging
+from typing import List
+import time
+import os
+import multiprocessing
+import emit_utils.file_checks
+
+from emit_utils.file_checks import envi_header
+
+def _write_bil_chunk(dat, outfile, line, shape, dtype = 'float32'):
+    """
+    Write a chunk of data to a binary, BIL formatted data cube.
+    Args:
+        dat: data to write
+        outfile: output file to write to
+        line: line of the output file to write to
+        shape: shape of the output file
+        dtype: output data type
+
+    Returns:
+        None
+    """
+    outfile = open(outfile, 'rb+')
+    outfile.seek(line * shape[1] * shape[2] * np.dtype(dtype).itemsize)
+    outfile.write(dat.astype(dtype).tobytes())
+    outfile.close()
+
+
+
+def single_image_ortho(img_dat, glt, glt_nodata_value=-9999):
+    """Orthorectify a single image
+    Args:
+        img_dat (array like): raw input image
+        glt (array like): glt - 2 band 1-based indexing for output file(x, y)
+        glt_nodata_value (int, optional): Value from glt to ignore. Defaults to 0.
+    Returns:
+        array like: orthorectified version of img_dat
+    """
+    outdat = np.zeros((glt.shape[0], glt.shape[1], img_dat.shape[-1])) - 9999
+    valid_glt = np.all(glt != glt_nodata_value, axis=-1)
+    glt[valid_glt] -= 1 # account for 1-based indexing
+    outdat[valid_glt, :] = img_dat[glt[valid_glt, 1], glt[valid_glt, 0], :]
+    return outdat, valid_glt
+
+
+def main(input_args=None):
+    parser = argparse.ArgumentParser(description="Robust MF")
+    parser.add_argument('glt_file', type=str,  metavar='GLT', help='path to glt image')   
+    parser.add_argument('raw_file', type=str,  metavar='RAW', help='path to raw image')   
+    parser.add_argument('out_file', type=str, metavar='OUTPUT', help='path to output image')   
+    parser.add_argument('--mosaic', action='store_true')
+    parser.add_argument('-b', type=int, nargs='+',default=-1)   
+    args = parser.parse_args(input_args)
+
+
+    glt_dataset = envi.open(envi_header(args.glt_file))
+    glt = glt_dataset.open_memmap(writeable=False, interleave='bip').copy()
+    del glt_dataset
+    glt_dataset = gdal.Open(args.glt_file)
+
+    if args.mosaic:
+        rawspace_files = np.squeeze(np.array(pd.read_csv(args.rawspace_file, header=None)))
+        # TODO: make this check more elegant, should run, catch all files present exception, and proceed
+        if args.run_with_missing_files is False:
+            emit_utils.file_checks.check_raster_files(rawspace_files, map_space=False)
+        # TODO: check that all rawspace files have same number of bands
+    else:
+        emit_utils.file_checks.check_raster_files([args.rawspace_file], map_space=False)
+        rawspace_files = [args.rawspace_file]
+
+    ort_img = None
+    for rawfile in rawspace_files:
+        img_ds = envi.open(envi_header(rawfile))
+        if args.b[0] == -1:
+            inds = np.arange(int(img_ds.metadata['bands']))
+        else:
+            inds = np.array(args.b)
+        img_dat = img_ds.open_memmap(writeable=False, interleave='bip')[...,inds].copy()
+
+        if ort_img is None:
+            ort_img, _ = single_image_ortho(img_dat, glt)
+        else:
+            ort_img_update, valid_glt = single_image_ortho(img_dat, glt)
+            ort_img[valid_glt, :] = ort_img_update[valid_glt, :]
+
+    band_names = None
+    if 'band names' in envi.open(envi_header(args.raw_file)).metadata.keys():
+        band_names = np.array(envi.open(envi_header(args.raw_file)).metadata['band names'],dtype=str)[inds].tolist()
+
+    # Build output dataset
+    driver = gdal.GetDriverByName('ENVI')
+    driver.Register()
+
+    #TODO: careful about output datatypes / format
+    outDataset = driver.Create(args.out_file, glt.shape[1], glt.shape[0],
+                               ort_img.shape[-1], gdal.GDT_Float32, options=['INTERLEAVE=BIL'])
+    outDataset.SetProjection(glt_dataset.GetProjection())
+    outDataset.SetGeoTransform(glt_dataset.GetGeoTransform())
+    for _b in range(1, ort_img.shape[-1]+1):
+        outDataset.GetRasterBand(_b).SetNoDataValue(-9999)
+        if band_names is not None:
+            outDataset.GetRasterBand(_b).SetDescription(band_names[_b-1])
+    del outDataset
+
+    _write_bil_chunk(ort_img.transpose((0,2,1)), args.out_file, 0, (glt.shape[0], ort_img.shape[-1], glt.shape[1]))
+
+
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/veg_correction.py
+++ b/veg_correction.py
@@ -42,6 +42,7 @@ def main(input_args=None):
     parser.add_argument('--out_file', type=str, default=None)   
     parser.add_argument('--soil_thresh', type=float, default=0.001)   
     parser.add_argument('--coarsened_file', type=str, default=None)   
+    parser.add_argument('--mask_fraction_file', type=str, default=None)   
     parser.add_argument('--resolution', type=float, default=None)   
     parser.add_argument('--data_threshold', type=float, default=None)   
     parser.add_argument('--abun_uncert_file', type=str, default=None)   
@@ -59,14 +60,22 @@ def main(input_args=None):
 
     abun = abun_ds.open_memmap(interleave='bip').copy()
     cover = cover_ds.open_memmap(interleave='bip')[...,2].copy()
+    counts = {}
+
     if args.thresh_only is False:
         abun = abun / cover[:,:,np.newaxis]
+
+    counts['no_abun'] = np.any(np.logical_or.reduce((np.isnan(abun) , np.isfinite(abun) == False, abun == -9999)),axis=-1)
     masked_out = np.any(np.isnan(abun), axis=-1)
     masked_out[np.any(np.isfinite(abun) == False,axis=-1)] = True
-    masked_out[cover < args.soil_thresh] = True
     masked_out[np.any(abun == -9999,axis=-1)] = True
+
+    counts['soil_cutoff'] = np.logical_and(masked_out == False, cover < args.soil_thresh)
+    masked_out[cover < args.soil_thresh] = True
+
     if args.mask_file is not None:
         ext_mask = gdal.Open(args.mask_file).ReadAsArray()
+        counts['external_mask'] = np.logical_and(masked_out == False, ext_mask == 1)
         masked_out[ext_mask == 1] = True
 
     abun[masked_out,:] = -9999
@@ -85,7 +94,6 @@ def main(input_args=None):
         abununcert[masked_out,:] = -9999
         coveruncert[masked_out] = -9999
         do_uncert = True
-
 
 
     # Build output dataset
@@ -117,6 +125,7 @@ def main(input_args=None):
         numy = int(round(abun.shape[0] / num_px))
         numx = int(round(abun.shape[1] / num_px))
         asa = np.zeros((numy, numx,abun.shape[2])) - 9999
+        agg_count = np.zeros((numy, numx,len(counts.keys()))) - 9999
         asa_unc = None
         if do_uncert:
             asa_unc = np.zeros((numy, numx,abun.shape[2])) - 9999
@@ -129,6 +138,8 @@ def main(input_args=None):
                     if complete_frac < args.data_threshold:
                         continue
                 asa[_y,_x,:] = np.nanmean(abun[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,:],axis=(0,1))
+                for _key, key in enumerate(counts.keys()):
+                    agg_count[_y,_x,_key] = np.sum(counts[key][_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px]) / np.product(abun[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,0].shape)
 
                 if do_uncert:
                     valid_unc = abununcert[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,:]
@@ -144,6 +155,7 @@ def main(input_args=None):
 
                     asa_unc[_y,_x,:] = np.sqrt(np.power(asa[_y,_x,:] / valid_px,2) * np.nansum(inner_term,axis=0))
 
+        # Spectral Abundance
         outDataset = driver.Create(args.coarsened_file, asa.shape[1], asa.shape[0],
                                    asa.shape[2], gdal.GDT_Float32, options=['INTERLEAVE=BIL'])
         outDataset.SetProjection(abun_gdal.GetProjection())
@@ -157,6 +169,23 @@ def main(input_args=None):
                 outDataset.GetRasterBand(_b).SetDescription(band_names[_b-1])
         del outDataset
         _write_bil_chunk(asa.transpose((0,2,1)), args.coarsened_file, 0, (asa.shape[0], asa.shape[2], asa.shape[1]))
+
+
+        # Count fractions
+        if args.mask_fraction_file is not None:
+            outDataset = driver.Create(args.mask_fraction_file, agg_count.shape[1], agg_count.shape[0],
+                                       agg_count.shape[2], gdal.GDT_Float32, options=['INTERLEAVE=BIL'])
+            outDataset.SetProjection(abun_gdal.GetProjection())
+            outtrans = list(abun_gdal.GetGeoTransform())
+            outtrans[1] = args.resolution
+            outtrans[5] = -1*args.resolution
+            outDataset.SetGeoTransform(outtrans)
+            for _b in range(1, agg_count.shape[2]+1):
+                outDataset.GetRasterBand(_b).SetNoDataValue(-9999)
+                if band_names is not None:
+                    outDataset.GetRasterBand(_b).SetDescription(list(counts.keys())[_b-1])
+            del outDataset
+            _write_bil_chunk(agg_count.transpose((0,2,1)), args.mask_fraction_file, 0, (agg_count.shape[0], agg_count.shape[2], agg_count.shape[1]))
 
         # Now uncertainty
         if do_uncert:

--- a/veg_correction.py
+++ b/veg_correction.py
@@ -1,0 +1,179 @@
+"""
+Apply a (possibly multi-file) per-pixel spatial reference, in serial (rayless).
+
+Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
+"""
+
+
+import argparse
+import numpy as np
+import pandas as pd
+import os
+from osgeo import gdal
+from spectral.io import envi
+import emit_utils.file_checks
+
+from emit_utils.file_checks import envi_header
+
+def _write_bil_chunk(dat, outfile, line, shape, dtype = 'float32'):
+    """
+    Write a chunk of data to a binary, BIL formatted data cube.
+    Args:
+        dat: data to write
+        outfile: output file to write to
+        line: line of the output file to write to
+        shape: shape of the output file
+        dtype: output data type
+
+    Returns:
+        None
+    """
+    outfile = open(outfile, 'rb+')
+    outfile.seek(line * shape[1] * shape[2] * np.dtype(dtype).itemsize)
+    outfile.write(dat.astype(dtype).tobytes())
+    outfile.close()
+
+
+
+def main(input_args=None):
+    parser = argparse.ArgumentParser(description="Robust MF")
+    parser.add_argument('abun_file', type=str)   
+    parser.add_argument('cover_file', type=str)   
+    parser.add_argument('out_file', type=str)   
+    parser.add_argument('--soil_thresh', type=float, default=0.001)   
+    parser.add_argument('--coarsened_file', type=str, default=None)   
+    parser.add_argument('--resolution', type=float, default=None)   
+    parser.add_argument('--data_threshold', type=float, default=None)   
+    parser.add_argument('--abun_uncert_file', type=str, default=None)   
+    parser.add_argument('--cover_uncert_file', type=str, default=None)   
+    args = parser.parse_args(input_args)
+
+
+    abun_ds = envi.open(envi_header(args.abun_file))
+    band_names = abun_ds.metadata['band names']
+    abun_gdal = gdal.Open(args.abun_file)
+    cover_ds = envi.open(envi_header(args.cover_file))
+
+    abun = abun_ds.open_memmap(interleave='bip').copy()
+    cover = cover_ds.open_memmap(interleave='bip')[...,2].copy()
+    abun = abun / cover[:,:,np.newaxis]
+    masked_out = np.any(np.isnan(abun), axis=-1)
+    masked_out[np.any(np.isfinite(abun) == False,axis=-1)] = True
+    masked_out[cover < args.soil_thresh] = True
+    masked_out[np.any(abun == -9999,axis=-1)] = True
+
+    abun[masked_out,:] = -9999
+    cover[masked_out] = -9999
+    #abun[np.isnan(abun)] = -9999
+    #abun[np.isfinite(abun) == False] = -9999
+    #abun[cover < args.soil_thresh,:] = -9999
+
+    do_uncert = False
+    if args.abun_uncert_file is not None and args.cover_uncert_file is not None and args.coarsened_file is not None and args.resolution is not None:
+        abununcert_ds = envi.open(envi_header(args.abun_uncert_file))
+        coveruncert_ds = envi.open(envi_header(args.cover_uncert_file))
+        abununcert = abununcert_ds.open_memmap(interleave='bip').copy()
+        coveruncert = coveruncert_ds.open_memmap(interleave='bip')[...,2].copy()
+
+        abununcert[masked_out,:] = -9999
+        coveruncert[masked_out] = -9999
+        do_uncert = True
+
+
+
+    # Build output dataset
+    driver = gdal.GetDriverByName('ENVI')
+    driver.Register()
+
+    #TODO: careful about output datatypes / format
+    outDataset = driver.Create(args.out_file, abun.shape[1], abun.shape[0],
+                               abun.shape[2], gdal.GDT_Float32, options=['INTERLEAVE=BIL'])
+    outDataset.SetProjection(abun_gdal.GetProjection())
+    outDataset.SetGeoTransform(abun_gdal.GetGeoTransform())
+    for _b in range(1, abun.shape[2]+1):
+        outDataset.GetRasterBand(_b).SetNoDataValue(-9999)
+        if band_names is not None:
+            outDataset.GetRasterBand(_b).SetDescription(band_names[_b-1])
+    del outDataset
+
+    _write_bil_chunk(abun.transpose((0,2,1)), args.out_file, 0, (abun.shape[0], abun.shape[2], abun.shape[1]))
+
+
+    if args.coarsened_file is not None and args.resolution is not None:
+
+        trans = abun_gdal.GetGeoTransform()
+        num_px = int(round(args.resolution / trans[1]))
+
+        abun[abun == -9999] = np.nan
+
+        numy = int(round(abun.shape[0] / num_px))
+        numx = int(round(abun.shape[1] / num_px))
+        asa = np.zeros((numy, numx,abun.shape[2])) - 9999
+        asa_unc = None
+        if do_uncert:
+            asa_unc = np.zeros((numy, numx,abun.shape[2])) - 9999
+
+        for _y in range(0,numy):
+            for _x in range(0,numx):
+                valid_px = np.sum(masked_out[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px] == False)
+                if args.data_threshold is not None:
+                    complete_frac = valid_px / float(num_px**2)
+                    print(complete_frac)
+                    if complete_frac < args.data_threshold:
+                        continue
+                asa[_y,_x,:] = np.nanmean(abun[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,:],axis=(0,1))
+
+                if do_uncert:
+                    valid_unc = abununcert[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,:]
+                    valid_subset = masked_out[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px] == False
+
+
+                    inner_term =  np.power(abununcert[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,:][valid_subset,:] / \
+                                           abun[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,:][valid_subset,:],2) +\
+                                  np.power(coveruncert[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px][valid_subset] / \
+                                           cover[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px][valid_subset],2)[:,np.newaxis]
+                    inner_term[abun[_y*num_px:(_y+1)*num_px,_x*num_px:(_x+1)*num_px,:][valid_subset,:] == 0] = np.nan
+                    
+
+                    asa_unc[_y,_x,:] = np.sqrt(np.power(asa[_y,_x,:] / valid_px,2) * np.nansum(inner_term,axis=0))
+
+        outDataset = driver.Create(args.coarsened_file, asa.shape[1], asa.shape[0],
+                                   asa.shape[2], gdal.GDT_Float32, options=['INTERLEAVE=BIL'])
+        outDataset.SetProjection(abun_gdal.GetProjection())
+        outtrans = list(abun_gdal.GetGeoTransform())
+        outtrans[1] = args.resolution
+        outtrans[5] = -1*args.resolution
+        outDataset.SetGeoTransform(outtrans)
+        for _b in range(1, asa.shape[2]+1):
+            outDataset.GetRasterBand(_b).SetNoDataValue(-9999)
+            if band_names is not None:
+                outDataset.GetRasterBand(_b).SetDescription(band_names[_b-1])
+        del outDataset
+        _write_bil_chunk(asa.transpose((0,2,1)), args.coarsened_file, 0, (asa.shape[0], asa.shape[2], asa.shape[1]))
+
+        # Now uncertainty
+        if do_uncert:
+            outDataset = driver.Create(args.coarsened_file + '_uncert', asa.shape[1], asa.shape[0],
+                                       asa.shape[2], gdal.GDT_Float32, options=['INTERLEAVE=BIL'])
+            outDataset.SetProjection(abun_gdal.GetProjection())
+            outtrans = list(abun_gdal.GetGeoTransform())
+            outtrans[1] = args.resolution
+            outtrans[5] = -1*args.resolution
+            outDataset.SetGeoTransform(outtrans)
+            for _b in range(1, asa_unc.shape[2]+1):
+                outDataset.GetRasterBand(_b).SetNoDataValue(-9999)
+                if band_names is not None:
+                    outDataset.GetRasterBand(_b).SetDescription(band_names[_b-1])
+            del outDataset
+            _write_bil_chunk(asa_unc.transpose((0,2,1)), args.coarsened_file + '_uncert', 0, (asa_unc.shape[0], asa_unc.shape[2], asa_unc.shape[1]))
+
+                   
+
+       
+
+
+if __name__ == '__main__':
+    main()
+
+
+


### PR DESCRIPTION
Provides a new option for a serial implementation of apply_glt.  This is a) rayless, and b) more streamlined for IO.  If bulk deploying apply_glt (e.g., for L3 runs), the new version uses 1/40th the resources with close to the same runtime.